### PR TITLE
format.cssの変更

### DIFF
--- a/format.css
+++ b/format.css
@@ -1,6 +1,6 @@
 body {
     margin: 0;
-    background-color: white;
+    background-color: darkcyan;
 
     display: flex;
     flex-direction: row;
@@ -8,6 +8,8 @@ body {
 }
 #main_contents {
     flex: 7;
+
+    background-color: white;
 }
 #sub_contents {
     flex: 2;


### PR DESCRIPTION
format.cssのスタイルを適用したページのコンテンツが短い時に、画面幅の狭いデバイスでページを閲覧すると、ページ下部が不自然に白色の背景となるのを修正した。